### PR TITLE
- Add UTF8 parameter to read config file. This avoid the following er…

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,26 +71,27 @@ set -g <option> "<value>"
 
 Where `<option>` and `<value>` are one of the specified here:
 
-| Option                      | Default  | Description |
-| :---                        | :---:    | :--- |
-| `@extrakto_key`             | `tab`    | The key binding to start. If you have any special requirements (like a custom key table) set this to 'none' and define a binding in your `.tmux.conf`. See `extrakto.tmux` for a sample. |
-| `@extrakto_split_direction` | `a`      | Whether the tmux split will be `a`uto, `p`opup, `v`ertical or `h`orizontal |
-| `@extrakto_split_size`      | `7`      | The size of the tmux split (for vertical/horizontal) |
-| `@extrakto_popup_size`      | `90%`    | Set width and height of the tmux popup window. Set this to `w,h` to set the width to `w` and height to `h`. |
-| `@extrakto_popup_position`  | `C`      | Set position of the tmux popup window. Possible values are in the `display-popup` entry in `man tmux`. Set this to `x,y` to set the x and y positions to `x` and `y` respectively. |
-| `@extrakto_grab_area`       | `full`   | Whether you want extrakto to grab data from the `recent` area, the `full` pane, all current window's `recent` areas or all current window's `full` panes. You can also set this option to any number you want (or number preceded by "window ", e.g. "window 500"), this allows you to grab a smaller amount of data from the pane(s) than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
-| `@extrakto_clip_tool`       | `auto`   | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. `auto` will try to choose the correct clipboard for your platform. |
-| `@extrakto_clip_tool_run`   | `bg`     | Set this to `fg` to have your clipboard tool run in a foreground shell (enabling [remote clipboard support](https://github.com/laktak/extrakto/wiki/Remote-Copy-via-OSC52)). |
-| `@extrakto_fzf_tool`        | `fzf`    | Set this to path of fzf if it can't be found in your `PATH`. |
-| `@extrakto_fzf_layout`      |`default` | Control the fzf layout which is "bottom-up" by default. If you prefer "top-down" layout instead set this to `reverse`. In fact, this value is passed to the fzf `--layout` parameter. Possible values are: `default`, `reverse` and `reverse-list` |
-| `@extrakto_open_tool`       | `auto`   | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
-| `@extrakto_copy_key`        | `enter`  | Key to copy selection to clipboard. |
-| `@extrakto_insert_key`      | `tab`    | Key to insert selection. |
-| `@extrakto_filter_key`      | `ctrl-f` | Key to toggle filter mode. |
-| `@extrakto_grab_key`        | `ctrl-g` | Key to toggle grab mode. |
-| `@extrakto_edit_key`        | `ctrl-e` | Key to run the editor. |
-| `@extrakto_open_key`        | `ctrl-o` | Key to run the open command. |
-| `@extrakto_default_opt`     | `word`   | **LEGACY** this option was removed in favor of the new filter mode. |
+| Option                            | Default  | Description |
+| :---                              | :---:    | :--- |
+| `@extrakto_key`                   | `tab`    | The key binding to start. If you have any special requirements (like a custom key table) set this to 'none' and define a binding in your `.tmux.conf`. See `extrakto.tmux` for a sample. |
+| `@extrakto_default_filter_mode`   | `line`   | Filter mode by default. Could be `line`, `word` or `all` |
+| `@extrakto_split_direction`       | `a`      | Whether the tmux split will be `a`uto, `p`opup, `v`ertical or `h`orizontal |
+| `@extrakto_split_size`            | `7`      | The size of the tmux split (for vertical/horizontal) |
+| `@extrakto_popup_size`            | `90%`    | Set width and height of the tmux popup window. Set this to `w,h` to set the width to `w` and height to `h`. |
+| `@extrakto_popup_position`        | `C`      | Set position of the tmux popup window. Possible values are in the `display-popup` entry in `man tmux`. Set this to `x,y` to set the x and y positions to `x` and `y` respectively. |
+| `@extrakto_grab_area`             | `full`   | Whether you want extrakto to grab data from the `recent` area, the `full` pane, all current window's `recent` areas or all current window's `full` panes. You can also set this option to any number you want (or number preceded by "window ", e.g. "window 500"), this allows you to grab a smaller amount of data from the pane(s) than the pane's limit. For instance, you may have a really big limit for tmux history but using the same limit may end up on having slow performance on Extrakto. |
+| `@extrakto_clip_tool`             | `auto`   | Set this to whatever clipboard tool you would like extrakto to use to copy data into your clipboard. `auto` will try to choose the correct clipboard for your platform. |
+| `@extrakto_clip_tool_run`         | `bg`     | Set this to `fg` to have your clipboard tool run in a foreground shell (enabling [remote clipboard support](https://github.com/laktak/extrakto/wiki/Remote-Copy-via-OSC52)). |
+| `@extrakto_fzf_tool`              | `fzf`    | Set this to path of fzf if it can't be found in your `PATH`. |
+| `@extrakto_fzf_layout`            |`default` | Control the fzf layout which is "bottom-up" by default. If you prefer "top-down" layout instead set this to `reverse`. In fact, this value is passed to the fzf `--layout` parameter. Possible values are: `default`, `reverse` and `reverse-list` |
+| `@extrakto_open_tool`             | `auto`   | Set this to path of your own tool or `auto` to use your platforms *open* implementation. |
+| `@extrakto_copy_key`              | `enter`  | Key to copy selection to clipboard. |
+| `@extrakto_insert_key`            | `tab`    | Key to insert selection. |
+| `@extrakto_filter_key`            | `ctrl-f` | Key to toggle filter mode. |
+| `@extrakto_grab_key`              | `ctrl-g` | Key to toggle grab mode. |
+| `@extrakto_edit_key`              | `ctrl-e` | Key to run the editor. |
+| `@extrakto_open_key`              | `ctrl-o` | Key to run the open command. |
+| `@extrakto_default_opt`           | `word`   | **LEGACY** this option was removed in favor of the new filter mode. |
 
 Example:
 

--- a/extrakto.py
+++ b/extrakto.py
@@ -111,12 +111,15 @@ class FilterDef:
         return res
 
 
-def get_lines(text, *, min_length=5, prefix_name=False):
+def get_lines(text, *, min_length=5, prefix_name=False, exclude_pattern=None):
     lines = []
 
     for raw_line in text.splitlines():
         line = raw_line.strip()
         if len(line) >= min_length:
+            if exclude_pattern:
+                if re.search(exclude_pattern, line):
+                    continue
             if prefix_name:
                 lines.append("line: " + line)
             else:
@@ -146,7 +149,7 @@ def main(parser):
         run_list = extrakto.all()
 
     if args.lines:
-        res += get_lines(text, min_length=args.min_length, prefix_name=args.name)
+        res += get_lines(text, min_length=args.min_length, prefix_name=args.name, exclude_pattern=args.exclude_pattern)
 
     for name in run_list:
         res += extrakto[name].filter(text)
@@ -204,6 +207,10 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--warn-empty", action="store_true", help="warn if result is empty"
+    )
+
+    parser.add_argument(
+        "-e", "--exclude-pattern", default=None, help="exclude pattern in line filter mode", type=str
     )
 
     main(parser)

--- a/extrakto.py
+++ b/extrakto.py
@@ -31,7 +31,7 @@ class Extrakto:
             os.path.expanduser("~/.config"), "extrakto/extrakto.conf"
         )
 
-        conf.read([default_conf, user_conf])
+        conf.read([default_conf, user_conf], "UTF-8")
         sections = conf.sections()
         if not "path" in sections or not "url" in sections:
             raise Exception("extrakto.conf incomplete")

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -133,7 +133,7 @@ show_fzf_error() {
 capture() {
     local mode header_tmpl header out res key text query
 
-    mode=word
+    mode=$(get_option "@extrakto_default_filter_mode")
     header_tmpl="${COLORS[BOLD]}${insert_key}${COLORS[OFF]}=insert"
     header_tmpl+=", ${COLORS[BOLD]}${copy_key}${COLORS[OFF]}=copy"
     [[ -n "$open_tool" ]] && header_tmpl+=", ${COLORS[BOLD]}${open_key}${COLORS[OFF]}=open"

--- a/scripts/extrakto.sh
+++ b/scripts/extrakto.sh
@@ -146,7 +146,7 @@ capture() {
         if [[ $mode == all ]]; then
             capture_panes | $extrakto --warn-empty --alt --all --name -r
         elif [[ $mode == line ]]; then
-            capture_panes | $extrakto --warn-empty -rl
+            capture_panes | $extrakto --warn-empty -rl --e '^\['
         else
             capture_panes | $extrakto --warn-empty -rw
         fi

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -22,6 +22,10 @@ get_option() {
             echo $(get_tmux_option $option "tab")
             ;;
 
+        "@extrakto_default_filter_mode")
+            echo $(get_tmux_option $option "all")
+            ;;
+
         "@extrakto_split_direction")
             echo $(get_tmux_option $option "a")
             ;;


### PR DESCRIPTION
Hello,
When trying to run extrakto on a Centos7, it fails because it was unable to read the config file due to some non-ASCII characters.
I added UTF-8 parameter to the read method and it worked fine.
Thanks.